### PR TITLE
[CSS] remove empty ruleset and combine repeated property

### DIFF
--- a/silktide-consent-manager.css
+++ b/silktide-consent-manager.css
@@ -290,7 +290,7 @@
 
 #silktide-modal .modal-close {
   display: inline-flex;
-  border: none, 0px;
+  border: none;
   padding: 13px;
   cursor: pointer;
   background: var(--backgroundColor);

--- a/silktide-consent-manager.css
+++ b/silktide-consent-manager.css
@@ -98,9 +98,6 @@
   border-radius: 5px;
 }
 
-#silktide-wrapper .st-button--primary {
-}
-
 #silktide-wrapper .st-button--primary:hover {
   background-color: var(--backgroundColor);
   color: var(--primaryColor);
@@ -293,9 +290,8 @@
 
 #silktide-modal .modal-close {
   display: inline-flex;
-  border: none;
+  border: none, 0px;
   padding: 13px;
-  border: 0px;
   cursor: pointer;
   background: var(--backgroundColor);
   color: var(--primaryColor);


### PR DESCRIPTION
These changes were necessary for the ShowIt site builder to accept the CSS, otherwise they cause errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes an empty ruleset and merges duplicate border declarations in the consent manager CSS.
> 
> - **CSS** (`silktide-consent-manager.css`):
>   - Remove empty ruleset `#silktide-wrapper .st-button--primary`.
>   - Combine duplicate `border` declarations in `#silktide-modal .modal-close` into a single declaration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit defcde6578e168270c2bdb1225638d9d4e73e5d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->