### PR TITLE
Accessibility polish: contrast, focus ring, and toggle label alignment

### DIFF
--- a/silktide-consent-manager.css
+++ b/silktide-consent-manager.css
@@ -52,7 +52,7 @@ Focus Styles
 #stcm-wrapper #stcm-modal button:focus,
 #stcm-wrapper #stcm-icon:focus {
   outline: none;
-  box-shadow: 0 0 0 2px var(--backgroundColor), 0 0 0 4px #ffffff;
+  box-shadow: 0 0 0 2px var(--backgroundColor), 0 0 0 4px var(--textColor);
   border-radius: 5px;
 }
 
@@ -303,7 +303,7 @@ Modal - Content
   font-size: 16px;
   line-height: 24px;
   color: var(--textColor);
-  opacity: 0.6;
+  opacity: 0.8;
   margin: 0px 0px 15px;
 }
 
@@ -350,7 +350,7 @@ Modal - Switches
 
 #stcm-modal .stcm-toggle:focus-within {
   outline: none;
-  box-shadow: 0 0 0 2px var(--backgroundColor), 0 0 0 4px #ffffff;
+  box-shadow: 0 0 0 2px var(--backgroundColor), 0 0 0 4px var(--textColor);
   border-radius: 25px;
 }
 
@@ -388,7 +388,7 @@ Modal - Switches
   font-weight: 500;
   color: var(--backgroundColor);
   position: absolute;
-  top: 5px;
+  top: 8px;
   right: 8px;
   transition: right 150ms ease-out, opacity 150ms ease-out;
 }
@@ -421,7 +421,7 @@ Modal - Switches
 }
 
 #stcm-modal .stcm-toggle input:disabled + .stcm-toggle-track {
-  opacity: 0.65;
+  opacity: 0.6;
   filter: grayscale(100%);
   cursor: not-allowed;
 }

--- a/silktide-consent-manager.js
+++ b/silktide-consent-manager.js
@@ -894,7 +894,7 @@ class SilktideConsentManager {
 
     // Silktide logo link
     const silktideLogo = `
-      <a class="stcm-logo" href="https://silktide.com/consent-manager" target="_blank" rel="noreferrer" aria-label="Visit the Silktide Consent Manager page">
+      <a class="stcm-logo" href="https://silktide.com/consent-manager" rel="noreferrer" aria-label="Visit the Silktide Consent Manager page">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="25" viewBox="0 0 24 25" fill="inherit">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M14.1096 16.7745C13.8895 17.2055 13.3537 17.3805 12.9129 17.1653L8.28443 14.9055L2.73192 17.7651L11.1025 21.9814C11.909 22.3876 12.8725 22.3591 13.6524 21.9058L20.4345 17.9645C21.2845 17.4704 21.7797 16.5522 21.7164 15.5872L21.7088 15.4704C21.6487 14.5561 21.0962 13.7419 20.2579 13.3326L15.6793 11.0972L10.2283 13.9045L13.71 15.6043C14.1507 15.8195 14.3297 16.3434 14.1096 16.7745ZM8.2627 12.9448L13.7136 10.1375L10.2889 8.46543C9.84803 8.25021 9.66911 7.72629 9.88916 7.29524C10.1093 6.86417 10.6451 6.68921 11.0859 6.90442L15.6575 9.13647L21.2171 6.27325L12.8808 2.03496C12.0675 1.62147 11.0928 1.65154 10.3078 2.11432L3.54908 6.09869C2.70732 6.59492 2.21846 7.50845 2.28139 8.46761L2.29003 8.59923C2.35002 9.51362 2.9026 10.3278 3.7409 10.7371L8.2627 12.9448ZM6.31884 13.9458L2.94386 12.2981C1.53727 11.6113 0.610092 10.2451 0.509431 8.71094L0.500795 8.57933C0.3952 6.96993 1.21547 5.4371 2.62787 4.60447L9.38662 0.620092C10.7038 -0.156419 12.3392 -0.206861 13.7039 0.486938L23.3799 5.40639C23.4551 5.44459 23.5224 5.4918 23.5811 5.54596C23.7105 5.62499 23.8209 5.73754 23.897 5.87906C24.1266 6.30534 23.9594 6.83293 23.5234 7.05744L17.6231 10.0961L21.0549 11.7716C22.4615 12.4583 23.3887 13.8245 23.4893 15.3587L23.497 15.4755C23.6033 17.0947 22.7724 18.6354 21.346 19.4644L14.5639 23.4057C13.2554 24.1661 11.6386 24.214 10.2854 23.5324L0.621855 18.6649C0.477299 18.592 0.361696 18.4859 0.279794 18.361C0.210188 18.2968 0.150054 18.2204 0.10296 18.133C-0.126635 17.7067 0.0406445 17.1792 0.47659 16.9546L6.31884 13.9458Z" fill="inherit"/>
         </svg>
@@ -1031,7 +1031,7 @@ class SilktideConsentManager {
     // Credit link
     const creditLinkText = this.config.text?.preferences?.creditLinkText || 'Get this consent manager for free';
     const creditLinkAccessibleLabel = this.config.text?.preferences?.creditLinkAccessibleLabel;
-    const creditLink = `<a class="stcm-credit-link" href="https://silktide.com/consent-manager" target="_blank" rel="noreferrer"${
+    const creditLink = `<a class="stcm-credit-link" href="https://silktide.com/consent-manager" rel="noreferrer"${
       creditLinkAccessibleLabel && creditLinkAccessibleLabel !== creditLinkText
         ? ` aria-label="${creditLinkAccessibleLabel}"`
         : ''


### PR DESCRIPTION
## Summary
- Vertically centre toggle ON/OFF labels (top: 5px → 8px)
- Focus ring outer uses \`var(--textColor)\` instead of hard-coded \`#ffffff\` so it stays visible on light-bg themes
- Modal body paragraph opacity 0.6 → 0.8 for improved AAA readability
- Silktide credit link and logo open in the current tab rather than a new tab

## Test plan
- [x] Toggle ON/OFF labels are vertically centred
- [x] Tab through the modal — focus ring visible on all themes (esp. light backgrounds)
- [x] Clicking the Silktide logo and "Get this consent manager for free" stays in current tab